### PR TITLE
Fix pressed state when scrolling inside a NestedScrollView

### DIFF
--- a/numberpicker/src/main/java/it/sephiroth/android/library/numberpicker/NumberPicker.kt
+++ b/numberpicker/src/main/java/it/sephiroth/android/library/numberpicker/NumberPicker.kt
@@ -280,7 +280,7 @@ class NumberPicker @JvmOverloads constructor(
                             }
                     }
 
-                    MotionEvent.ACTION_UP -> {
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                         upButton.isPressed = false
                         buttonInterval?.dispose()
                         buttonInterval = null
@@ -318,7 +318,7 @@ class NumberPicker @JvmOverloads constructor(
                             }
                     }
 
-                    MotionEvent.ACTION_UP -> {
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                         downButton.isPressed = false
 
                         buttonInterval?.dispose()


### PR DESCRIPTION
This fixes the issue I'm facing when using NumberSlidingPicker inside a NestedScrollView. When scrolling the arrow buttons can stay in a pressed state which makes the progress increment.