### PR TITLE
Give access to underlying editText view

### DIFF
--- a/numberpicker/src/main/java/it/sephiroth/android/library/numberpicker/NumberPicker.kt
+++ b/numberpicker/src/main/java/it/sephiroth/android/library/numberpicker/NumberPicker.kt
@@ -45,7 +45,8 @@ class NumberPicker @JvmOverloads constructor(
 
     var numberPickerChangeListener: OnNumberPickerChangeListener? = null
 
-    private lateinit var editText: EditText
+    lateinit var editText: EditText
+        private set
     private lateinit var upButton: AppCompatImageButton
     private lateinit var downButton: AppCompatImageButton
     private lateinit var tracker: Tracker


### PR DESCRIPTION
Hi this is more of a suggestion than a full blown PR but I started to use NumberSlidingPicker and I found myself wanting to use input mask and or other extension for EditText (eg https://github.com/RedMadRobot/input-mask-android). Most of them require a either reference to the EditText or extend it through inheritance and changing `editText` visibility help for the first case.
I don't have a lot of experience in Java or Kotlin so there might be issues or side effects with my solution.